### PR TITLE
iOSのBroadcast Upload Extensionでのメモリ使用量を削減する

### DIFF
--- a/build.ios.sh
+++ b/build.ios.sh
@@ -33,6 +33,7 @@ pushd $SOURCE_DIR/webrtc/src
   patch -p1 < $SCRIPT_DIR/patches/macos_simulcast.patch
   patch -p1 < $SCRIPT_DIR/patches/ios_manual_audio_input.patch
   patch -p1 < $SCRIPT_DIR/patches/ios_simulcast.patch
+  patch -p1 < $SCRIPT_DIR/patches/ios_thread_priority.patch
 popd
 
 for build_config in $TARGET_BUILD_CONFIGS; do
@@ -53,6 +54,7 @@ pushd $SOURCE_DIR/webrtc/src
       rtc_include_tests=false \
       rtc_build_examples=false \
       rtc_use_h264=false \
+      rtc_enable_protobuf=false \
       use_rtti=true \
       libcxx_abi_unstable=false \
       enable_dsyms=$_is_debug \
@@ -104,6 +106,7 @@ pushd $SOURCE_DIR/webrtc/src
         rtc_include_tests=false
         rtc_build_examples=false
         rtc_use_h264=false
+        rtc_enable_protobuf=false
         use_rtti=true
         libcxx_abi_unstable=false
       "

--- a/build.macos_arm64.sh
+++ b/build.macos_arm64.sh
@@ -28,7 +28,7 @@ pushd $SOURCE_DIR/webrtc/src
   patch -p2 < $SCRIPT_DIR/patches/macos_screen_capture.patch
   patch -p1 < $SCRIPT_DIR/patches/macos_simulcast.patch
   patch -p1 < $SCRIPT_DIR/patches/ios_simulcast.patch
-  patch -p1 < $SCRIPT_DIR/patches/ios_thread_priority.patch
+  patch -p1 < $SCRIPT_DIR/patches/macos_thread_priority.patch
   patch -p1 < $SCRIPT_DIR/patches/macos_use_metal.patch
 popd
 

--- a/build.macos_x86_64.sh
+++ b/build.macos_x86_64.sh
@@ -28,7 +28,7 @@ pushd $SOURCE_DIR/webrtc/src
   patch -p2 < $SCRIPT_DIR/patches/macos_screen_capture.patch
   patch -p1 < $SCRIPT_DIR/patches/macos_simulcast.patch
   patch -p1 < $SCRIPT_DIR/patches/ios_simulcast.patch
-  patch -p1 < $SCRIPT_DIR/patches/ios_thread_priority.patch
+  patch -p1 < $SCRIPT_DIR/patches/macos_thread_priority.patch
   patch -p1 < $SCRIPT_DIR/patches/macos_use_metal.patch
 popd
 

--- a/patches/ios_thread_priority.patch
+++ b/patches/ios_thread_priority.patch
@@ -56,3 +56,46 @@ index 4df19bc297..408c1e0258 100644
 +        dispatch_queue_create("org.webrtc.RTCDispatcherNetworkMonitor", DISPATCH_QUEUE_CONCURRENT);
    });
  }
+diff --git a/video/video_receive_stream.cc b/video/video_receive_stream.cc
+index dbdba388aa..78556f4846 100644
+--- a/video/video_receive_stream.cc
++++ b/video/video_receive_stream.cc
+@@ -223,7 +223,7 @@ VideoReceiveStream::VideoReceiveStream(
+       max_wait_for_frame_ms_(kMaxWaitForFrameMs),
+       decode_queue_(task_queue_factory_->CreateTaskQueue(
+           "DecodingQueue",
+-          TaskQueueFactory::Priority::HIGH)) {
++          TaskQueueFactory::Priority::LOW)) {
+   RTC_LOG(LS_INFO) << "VideoReceiveStream: " << config_.ToString();
+
+   RTC_DCHECK(config_.renderer);
+diff --git a/video/video_receive_stream2.cc b/video/video_receive_stream2.cc
+index c9ec9e0123..58cb834e6c 100644
+--- a/video/video_receive_stream2.cc
++++ b/video/video_receive_stream2.cc
+@@ -258,7 +258,7 @@ VideoReceiveStream2::VideoReceiveStream2(
+       maximum_pre_stream_decoders_("max", kDefaultMaximumPreStreamDecoders),
+       decode_queue_(task_queue_factory_->CreateTaskQueue(
+           "DecodingQueue",
+-          TaskQueueFactory::Priority::HIGH)) {
++          TaskQueueFactory::Priority::LOW)) {
+   RTC_LOG(LS_INFO) << "VideoReceiveStream2: " << config_.ToString();
+
+   RTC_DCHECK(worker_thread_);
+diff --git a/video/video_stream_decoder_impl.cc b/video/video_stream_decoder_impl.cc
+index b6d754e8be..2139ce8c76 100644
+--- a/video/video_stream_decoder_impl.cc
++++ b/video/video_stream_decoder_impl.cc
+@@ -35,10 +35,10 @@ VideoStreamDecoderImpl::VideoStreamDecoderImpl(
+       frame_buffer_(Clock::GetRealTimeClock(), &timing_, nullptr),
+       bookkeeping_queue_(task_queue_factory->CreateTaskQueue(
+           "video_stream_decoder_bookkeeping_queue",
+-          TaskQueueFactory::Priority::NORMAL)),
++          TaskQueueFactory::Priority::LOW)),
+       decode_queue_(task_queue_factory->CreateTaskQueue(
+           "video_stream_decoder_decode_queue",
+-          TaskQueueFactory::Priority::NORMAL)) {
++          TaskQueueFactory::Priority::LOW)) {
+   bookkeeping_queue_.PostTask([this]() {
+     RTC_DCHECK_RUN_ON(&bookkeeping_queue_);
+     StartNextDecode();

--- a/patches/macos_thread_priority.patch
+++ b/patches/macos_thread_priority.patch
@@ -1,0 +1,58 @@
+diff --git a/call/rtp_transport_controller_send.cc b/call/rtp_transport_controller_send.cc
+index d743a0bf43..2b6a3209bd 100644
+--- a/call/rtp_transport_controller_send.cc
++++ b/call/rtp_transport_controller_send.cc
+@@ -125,7 +125,7 @@ RtpTransportControllerSend::RtpTransportControllerSend(
+       retransmission_rate_limiter_(clock, kRetransmitWindowSizeMs),
+       task_queue_(task_queue_factory->CreateTaskQueue(
+           "rtp_send_controller",
+-          TaskQueueFactory::Priority::NORMAL)) {
++          TaskQueueFactory::Priority::HIGH)) {
+   ParseFieldTrial({&relay_bandwidth_cap_},
+                   trials->Lookup("WebRTC-Bwe-NetworkRouteConstraints"));
+   initial_config_.constraints = ConvertConstraints(bitrate_config, clock_);
+diff --git a/video/video_stream_encoder.cc b/video/video_stream_encoder.cc
+index 191918a591..39991e0d59 100644
+--- a/video/video_stream_encoder.cc
++++ b/video/video_stream_encoder.cc
+@@ -659,7 +659,7 @@ VideoStreamEncoder::VideoStreamEncoder(
+           !field_trial::IsEnabled("WebRTC-QpParsingKillSwitch")),
+       encoder_queue_(task_queue_factory->CreateTaskQueue(
+           "EncoderQueue",
+-          TaskQueueFactory::Priority::NORMAL)) {
++          TaskQueueFactory::Priority::HIGH)) {
+   RTC_DCHECK(main_queue_);
+   RTC_DCHECK(encoder_stats_observer);
+   RTC_DCHECK_GE(number_of_cores, 1);
+diff --git a/modules/pacing/task_queue_paced_sender.cc b/modules/pacing/task_queue_paced_sender.cc
+index 709718ff16..d8f9b4c17c 100644
+--- a/modules/pacing/task_queue_paced_sender.cc
++++ b/modules/pacing/task_queue_paced_sender.cc
+@@ -50,7 +50,7 @@ TaskQueuePacedSender::TaskQueuePacedSender(
+       is_shutdown_(false),
+       task_queue_(task_queue_factory->CreateTaskQueue(
+           "TaskQueuePacedSender",
+-          TaskQueueFactory::Priority::NORMAL)) {}
++          TaskQueueFactory::Priority::HIGH)) {}
+
+ TaskQueuePacedSender::~TaskQueuePacedSender() {
+   // Post an immediate task to mark the queue as shutting down.
+diff --git a/sdk/objc/helpers/RTCDispatcher.m b/sdk/objc/helpers/RTCDispatcher.m
+index 4df19bc297..408c1e0258 100644
+--- a/sdk/objc/helpers/RTCDispatcher.m
++++ b/sdk/objc/helpers/RTCDispatcher.m
+@@ -21,12 +21,12 @@ + (void)initialize {
+   dispatch_once(&onceToken, ^{
+     kAudioSessionQueue = dispatch_queue_create(
+         "org.webrtc.RTCDispatcherAudioSession",
+-        DISPATCH_QUEUE_SERIAL);
++        DISPATCH_QUEUE_CONCURRENT);
+     kCaptureSessionQueue = dispatch_queue_create(
+         "org.webrtc.RTCDispatcherCaptureSession",
+-        DISPATCH_QUEUE_SERIAL);
++        DISPATCH_QUEUE_CONCURRENT);
+     kNetworkMonitorQueue =
+-        dispatch_queue_create("org.webrtc.RTCDispatcherNetworkMonitor", DISPATCH_QUEUE_SERIAL);
++        dispatch_queue_create("org.webrtc.RTCDispatcherNetworkMonitor", DISPATCH_QUEUE_CONCURRENT);
+   });
+ }


### PR DESCRIPTION
- protocol_buffer をビルド対象から除外する
- 映像送信のスレッドと受信のスレッドの優先順位を変更する